### PR TITLE
Fix for unwanted artifact subdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifndef version
 	$(error No version given. Aborting)
 endif
 	$(eval tmpdir:=$(shell mktemp -d build-XXXXXXXXXX))
-	cp -r $(local) $(tmpdir)
+	cp -r $(local)/* $(tmpdir)
 	cd $(tmpdir); zip -r ../$(artifact_name)-$(version).zip *
 	rm -rf $(tmpdir)
 


### PR DESCRIPTION
This change removes the `local` subdirectory from the root of the files enclosed within the archive to make decompression more flexible.