### PR TITLE
Update Net-CompaniesHouse library version to 0.66 to use certified copies endpoint

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,7 @@ requires 'Moose', '==2.1402';
 
 requires 'CH::MojoX::Administration::Plugin', '==0.35';
 requires 'Net::CompaniesHouse::Admin', '==0.36'
-requires 'Net::CompaniesHouse', '==0.65';
+requires 'Net::CompaniesHouse', '==0.66';
 requires 'CH::MojoX::Plugin::API', '==0.40';
 requires 'CH::MojoX::Plugin::Config', '==0.31';
 requires 'CH::MojoX::Plugin::Exception', '==0.31';


### PR DESCRIPTION
Up version to latest `0.66`

New version on `Net-CompaniesHouse` added to SmartPan
https://smartpan.ci.platform.aws.chdev.org/?q=Net-CompaniesHouse

