### PR TITLE
Using the latest version of CH::Mojox::Signin plugin

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -26,7 +26,7 @@ requires 'CH::MojoX::Plugin::Exception', '==0.31';
 requires 'CH::MojoX::Plugin::HealthCheck', '==0.11';
 requires 'CH::MojoX::Plugin::QueueAPI', '==0.31';
 requires 'CH::MojoX::Plugin::Xslate', '==0.34';
-requires 'CH::MojoX::SignIn::Plugin', '==0.50';
+requires 'CH::MojoX::SignIn::Plugin', '==0.51';
 requires 'CH::Perl', '==0.31';
 requires 'Crypt::Rijndael', '==1.12';
 requires 'Data::Dumper::Concise', '==2.023';


### PR DESCRIPTION
Previous version of the plugin had artefact errors, hence updating the reference to point to the latest version.